### PR TITLE
Change license to MIT with Commons Clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,300 +2,45 @@ CodeRelay License — Creative Commons Attribution-NonCommercial 4.0 Internation
 
 Copyright (c) 2026 CodeRelay contributors
 
-By exercising the Licensed Rights (defined below), You accept and agree to be
-bound by the terms and conditions of this Creative Commons Attribution-
-NonCommercial 4.0 International Public License ("Public License"). To the extent
-this Public License may be interpreted as a contract, You are granted the
-Licensed Rights in consideration of Your acceptance of these terms and
-conditions, and the Licensor grants You such rights in consideration of
-benefits the Licensor receives from making the Licensed Material available
-under these terms and conditions.
-
-Section 1 — Definitions.
-
-  a. Adapted Material means material subject to Copyright and Similar Rights
-     that is derived from or based upon the Licensed Material and that is
-     not subject to Copyright and Similar Rights, as defined by the Licensor.
-     For purposes of this Public License, where the Licensed Material is a
-     musical work, performance, or sound recording, Adapted Material is
-     always produced from the Licensed Material.
-
-  b. Adapter's License means the license You apply to Your Copyright and
-     Similar Rights in Your contributions to Adapted Material in accordance
-     with the terms and conditions of this Public License.
-
-  c. Copyright and Similar Rights means copyright and/or similar rights
-     closely related to copyright including, without limitation, performance,
-     broadcast, sound recording, and Sui Generis Database Rights, without
-     regard to how the rights are labeled or categorized. For purposes of
-     this Public License, the rights specified in Section 2(b)(1)-(2) are
-     not Copyright and Similar Rights.
-
-  d. Effective Technological Measures means those measures that, in the
-     absence of proper authority, may not be circumvented under laws
-     fulfilling obligations under Article 11 of the WIPO Copyright Treaty
-     adopted on December 20, 1996, and/or similar international agreements.
-
-  e. Exceptions and Limitations means fair use, fair dealing, and/or any
-     other exception or limitation to Copyright and Similar Rights that
-     applies to Your use of the Licensed Material.
-
-  f. Licensed Material means the artistic or literary work, database, or
-     other material to which the Licensor applied this Public License.
-
-  g. Licensed Rights means the rights granted to You subject to the terms
-     and conditions of this Public License, which are limited to all
-     Copyright and Similar Rights that apply to Your use of the Licensed
-     Material and that the Licensor has authority to license.
-
-  h. Licensor means the individual(s) or entity(ies) granting rights under
-     this Public License.
-
-  i. NonCommercial means not primarily intended for or directed towards
-     commercial advantage or monetary compensation. For purposes of this
-     Public License, the exchange of the Licensed Material for other material
-     subject to Copyright and Similar Rights by digital file-sharing or
-     similar means is NonCommercial provided there is no payment of monetary
-     compensation in connection with the exchange.
-
-  j. Licensor means the individual(s) or entity(ies) granting rights under
-     this Public License.
-
-  k. You means the individual or entity exercising the Licensed Rights
-     under this Public License. Your has a corresponding meaning.
-
-Section 2 — Scope.
-
-  a. License grant.
-
-     1. Subject to the terms and conditions of this Public License, the
-        Licensor hereby grants You a worldwide, royalty-free, non-sublicensable,
-        non-exclusive, irrevocable license to exercise the Licensed Rights
-        in the Licensed Material to:
-
-          A. reproduce and Share the Licensed Material, in whole or in part,
-             for NonCommercial purposes only; and
-
-          B. produce, reproduce, and Share Adapted Material for NonCommercial
-             purposes only.
-
-     2. Exceptions and Limitations. For the avoidance of doubt, where
-        Exceptions and Limitations apply to Your use, this Public License
-        does not apply, and You do not need to comply with its terms and
-        conditions.
-
-     3. Term. The term of this Public License is specified in Section 6(a).
-
-     4. Media and formats; technical modifications allowed. The Licensor
-        authorizes You to exercise the Licensed Rights in all media and
-        formats whether now known or hereafter created, and to make technical
-        modifications necessary to do so. The Licensor waives and/or agrees
-        not to assert any right or authority to forbid You from making
-        technical modifications necessary to exercise the Licensed Rights,
-        including technical modifications necessary to circumvent Effective
-        Technological Measures.
-
-     5. Downstream recipients.
-
-          A. Offer from the Licensor — Licensed Material. Every recipient of
-             the Licensed Material automatically receives an offer from the
-             Licensor to exercise the Licensed Rights under the terms and
-             conditions of this Public License.
-
-          B. No downstream restrictions. You may not offer or impose any
-             additional or different terms or conditions on, or apply any
-             Effective Technological Measures to, the Licensed Material if
-             doing so restricts exercise of the Licensed Rights by any
-             recipient of the Licensed Material.
-
-     6. No endorsement. Nothing in this Public License constitutes or may be
-        construed as permission to assert or imply that You are, or that Your
-        use of the Licensed Material is, connected with, or sponsored,
-        endorsed, or granted official status by, the Licensor or others
-        designated to receive attribution as provided in Section 3(a)(1)(A)(i).
-
-  b. Other rights.
-
-     1. Moral rights, such as the right of integrity, are not licensed
-        under this Public License, nor are publicity, privacy, and/or other
-        similar personality rights; however, to the extent possible, the
-        Licensor waives and/or agrees not to assert any such rights held by
-        the Licensor to the limited extent necessary to allow You to
-        exercise the Licensed Rights, but not otherwise.
-
-     2. Patent and trademark rights are not licensed under this Public
-        License.
-
-     3. To the extent possible, the Licensor waives any right to collect
-        royalties from You for the exercise of the Licensed Rights, whether
-        directly or through a collecting society under any voluntary or
-        waivable statutory or compulsory licensing scheme. In all other
-        cases, the Licensor reserves the right to collect such royalties,
-        including when the Licensed Material is used other than for
-        NonCommercial purposes.
-
-Section 3 — License Conditions.
-
-Your exercise of the Licensed Rights is expressly made subject to the
-following conditions.
-
-  a. Attribution.
-
-     1. If You Share the Licensed Material (including in modified form), You
-        must:
-
-          A. retain the following if it is supplied by the Licensor with
-             the Licensed Material:
-
-             i. identification of the creator(s) of the Licensed Material
-                and any others designated to receive attribution, in any
-                reasonable manner requested by the Licensor (including by
-                pseudonym if designated);
-
-             ii. a copyright notice;
-
-             iii. a notice that refers to this Public License;
-
-             iv. a notice that refers to the disclaimer of warranties;
-
-             v. a URI or hyperlink to the Licensed Material to the extent
-                reasonably practicable;
-
-          B. indicate if You modified the Licensed Material and retain an
-             indication of any previous modifications; and
-
-          C. indicate the Licensed Material is licensed under this Public
-             License, and include the text of, or the URI or hyperlink to,
-             this Public License.
-
-     2. You may satisfy the conditions in Section 3(a)(1) in any reasonable
-        manner based on the medium, means, and context in which You Share
-        the Licensed Material. For example, it may be reasonable to satisfy
-        the conditions by providing a URI or hyperlink to a resource that
-        includes the required information.
-
-     3. If requested by the Licensor, You must remove any of the information
-        required by Section 3(a)(1)(A) to the extent reasonably practicable.
-
-  b. ShareAlike. The condition in Section 3(a) does not apply to Adapted
-     Material licensed under Adapted Material's Adapter's License.
-
-Section 4 — Sui Generis Database Rights.
-
-Where the Licensed Rights include Sui Generis Database Rights that apply to
-Your use of the Licensed Material:
-
-  a. for the avoidance of doubt, Section 2(a)(1) grants You the right to
-     extract, reuse, reproduce, and Share all or a substantial portion of
-     the contents of the database for NonCommercial purposes only;
-
-  b. if You include all or a substantial portion of the database contents in
-     a database in which You have Sui Generis Database Rights, then the
-     database in which You have Sui Generis Database Rights (but not its
-     individual contents) is Adapted Material, including for purposes of
-     Section 3(b); and
-
-  c. You must comply with the conditions in Section 3(a) if You Share all or
-     a substantial portion of the contents of the database.
-
-For the avoidance of doubt, this Section 4 supplements and does not replace
-Your obligations under this Public License where the Licensed Rights include
-other Copyright and Similar Rights.
-
-Section 5 — Disclaimer and Limitation of Liability.
-
-  a. Unless the Licensor separately assumes responsibility for the Licensed
-     Material, to the maximum extent possible, the Licensed Material is
-     provided on an "as is" and "as available" basis. The Licensor makes
-     no warranties or representations of any kind concerning the Licensed
-     Material, whether express, implied, statutory, or other. This includes,
-     without limitation, any warranties of title, merchantability, fitness
-     for a particular purpose, non-infringement, absence of latent or other
-     defects, accuracy, or the presence or absence of errors, whether or
-     not known or discoverable. Where disclaimers of warranties are not
-     allowed in full or in part, this disclaimer may not apply to You.
-
-  b. To the maximum extent possible, in no event will the Licensor be liable
-     to You on any legal theory (including, without limitation, negligence)
-     or otherwise for any direct, special, indirect, incidental,
-     consequential, punitive, exemplary, or other losses, costs, expenses,
-     or damages arising out of this Public License or use of the Licensed
-     Material, even if the Licensor has been advised of the possibility of
-     such losses, costs, expenses, or damages. Where a limitation of
-     liability is not allowed in full or in part, this limitation may not
-     apply to You.
-
-  c. The disclaimer of warranties and limitation of liability provided in
-     this Section 5 shall be interpreted in a manner that, to the extent
-     possible, most closely approximates an absolute disclaimer and waiver
-     of all liability.
-
-Section 6 — Term and Termination.
-
-  a. This Public License applies for the term of the Copyright and Similar
-     Rights licensed here. However, if You fail to comply with this Public
-     License, then Your rights under this Public License are automatically
-     terminated.
-
-  b. Where Your right to use the Licensed Material has terminated under
-     Section 6(a), it reinstates:
-
-     1. automatically as of the date the violation is cured, provided it is
-        cured within 30 days of Your discovery of the violation; or
-
-     2. upon express reinstatement by the Licensor.
-
-     For the avoidance of doubt, this Section 6(b) does not affect any right
-     the Licensor may have to seek remedies for Your violations of this
-     Public License.
-
-  c. For the avoidance of doubt, the Licensor may also offer the Licensed
-     Material under separate terms or conditions or stop distributing the
-     Licensed Material at any time; however, doing so will not terminate
-     this Public License.
-
-  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
-
-Section 7 — Other Terms and Conditions.
-
-  a. The Licensor shall be bound by any additional or different terms or
-     conditions communicated by You under Section 4(a) of the Creative
-     Commons Attribution-NonCommercial 4.0 International License.
-
-  b. Any arrangements, understandings, or agreements regarding the Licensed
-     Material not stated herein are separate from and independent of the
-     terms and conditions of this Public License.
-
-Section 8 — Interpretation.
-
-  a. For the avoidance of doubt, this Public License does not, and shall not
-     be interpreted to, reduce, limit, restrict, or impose conditions on any
-     use of the Licensed Material that could lawfully be made without
-     permission under this Public License.
-
-  b. To the extent possible, if any provision of this Public License is
-     deemed unenforceable, it shall be automatically modified to the
-     minimum extent necessary to make it enforceable. If the provision
-     cannot be modified, it shall be deemed severed from this Public License
-     without affecting the validity of the remaining terms and conditions.
-
-  c. No term or condition of this Public License will be waived and no
-     failure to comply with it consented to unless expressly agreed to by
-     the Licensor.
-
-  d. Nothing in this Public License constitutes or may be interpreted as a
-     limitation upon, or waiver of, any privileges and immunities that apply
-     to the Licensor or You, including from the legal processes of any
-     jurisdiction or authority.
-
-=======================================================================
-
-Creative Commons Attribution-NonCommercial 4.0 International Public License
-
-For the full text of this license, visit:
-https://creativecommons.org/licenses/by-nc/4.0/legalcode
-
-Summary: You are free to share and adapt this software for any non-commercial
-purpose, provided you give appropriate credit, indicate if changes were made,
-and do not apply legal terms or technological measures that restrict others
-from doing anything the license permits. Commercial use is strictly prohibited.
+MIT License with Commons Clause
+
+=== Commons Clause License Condition v1.0 ===
+
+The Software is provided to you by the Licensor under the MIT License below,
+subject to the following condition:
+
+Without limiting other conditions in the License, the grant of rights under
+the License will not include, and the License does not grant to you,
+the right to Sell the Software.
+
+For purposes of the foregoing, "Sell" means practicing any or all of the
+rights granted to you under the License to provide to third parties,
+for a fee or other consideration (including without limitation fees for
+hosting or consulting/support services related to the Software),
+a product or service whose value derives, entirely or substantially,
+from the functionality of the Software.
+
+Any license notice or attribution required by the License must also include
+this Commons Clause License Condition notice.
+
+=== MIT License ===
+
+Copyright (c) 2026 CodeRelay contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Updated the license from Creative Commons Attribution-NonCommercial 4.0 to MIT License with Commons Clause, including specific conditions regarding the use and sharing of the software.